### PR TITLE
Four minor blitter fixes

### DIFF
--- a/gambaterm/run.py
+++ b/gambaterm/run.py
@@ -132,7 +132,7 @@ def run(
                     maybe_clear_seq = b"\033[H\033[2J"
                     height, width = new_size
                     refx, refy = get_ref(width, height, console)
-                    last_frame = ~video
+                    last_frame.fill(0)
                 else:
                     maybe_clear_seq = b""
                 # Render frame with synchronized output mode (DEC 2026) to prevent flickering

--- a/termblit_ext/termblit.pyx
+++ b/termblit_ext/termblit.pyx
@@ -154,10 +154,10 @@ cdef char* _blit(
 
     cdef int current_x = refx
     cdef int current_y = refy
-    # Use values that can never match a real pixel (high byte is always
-    # 0xFF in GB pixel format)
-    cdef uint32_t current_fg = 0x00DEAD00
-    cdef uint32_t current_bg = 0x00BEEF00
+    # Use 0x0 as "undrawn" sentinel: real GB pixels always have 0xFF
+    # in the high byte, so 0x0 can never match
+    cdef uint32_t current_fg = 0x0
+    cdef uint32_t current_bg = 0x0
     cdef int row_index, column_index
     cdef uint32_t color1, color2
     cdef int new_x, new_y


### PR DESCRIPTION
The blitter's ``current_fg`` and ``current_bg`` were initialized to -1 (0xFFFFFFFF) and -2 (0xFFFFFFFE). Since GB pixels use 0xFF as the high byte, 0xFFFFFFFF is valid "full white" screen.

Problems
-------------

1. On the first frame, white pixels match exactly during the boot rom "Nintendo" logo, so the blitter skipped emitting the "foreground SGR", rendering these in its default foreground color. But for many terminals, the foreground is not white, but off-white, causing some greyish color and "artifact" white blocks during the logo "fade out".

2. On resize, last_frame.fill(0xFFFFFFFF) was used to force a full redraw, but white pixels in the video buffer matched this value exactly! so resizes during the boot rom "nintendo logo" especially will cause corrupted redraws or artifacts.

3. When resizing, the "clear" sequence is used and this causes "flickering". This can be solved in a majority of popular modern terminals using a DEC Sequence (see [my results](https://ucs-detect.readthedocs.io/results.html#terminal-capabilities) under column "Synched Output" for an exact list of terminals where flickering is fixed)

4. "fast sprite blinking" meant to cause "transparency" effects on original hardware causes "rolling black bars" as it rapidly erases and draws a sprite, there are moments in the terminal refresh cycle where it is drawn as only half-drawn or half-erased. This has something like an effect of recording an old CRT with a video camera, called "rolling bands".

To reproduce: use "Konsole" or any other terminal without support for synchronized output with the Zelda game intro shown, there will be black "bands" that roll across the flashing sprite. I am unable to capture this effect by video recording (I think I am unable to record at full 60+FPS or capture how X11 frames are synchronized with output).

https://github.com/user-attachments/assets/0f391c3c-8b16-4e31-aab4-bc53c71f36ee

Solution
------------

- Use nonsense values, ``0x00DEAD00`` and ``0x00BEEF00`` as initial values. These have ``0x00`` in the high byte which never matches a real GB pixel (which always has 0xFF there).

- Reset "last_frame" value as the inverse of the current frame on resize, this forces a "full draw" on resize which is exactly what we want in all cases after the "clear" sequence is emitted.

- By using synchronized output sequence, we can prevent flickering and "rolling bars" of rapid sprite blinks by instructing the terminal to perform a kind of classic "double buffering" technique usually by drawing "off screen" and performing a swap of the video frame. Terminals that do not support this sequence safely ignore it and continue to flicker during resize.

https://github.com/user-attachments/assets/b199a290-c902-4cdd-a671-807cc5d0ca4b