### PR TITLE
audio logging and diagnostics with structlog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     - id: trailing-whitespace
       exclude: \.patch$
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.7.0"
+    rev: "v2.3.0"
     hooks:
     - id: mypy
       additional_dependencies: [

--- a/gambaterm/audio.py
+++ b/gambaterm/audio.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import atexit
+import os
 from typing import Generator, Iterator, TYPE_CHECKING
 from contextlib import contextmanager
 from collections import deque
@@ -50,20 +52,39 @@ class AudioOut:
         self.ring_buffer = np.zeros((self.ring_size, 2), dtype=np.int16)
 
         # We implement a SPSC (Single Producer Single Consumer) ring buffer,
-        # so we do not need synchonization primitives. The contract is:
-        # - only the producer (the `send` method) can incremement the write counter
+        # so we do not need synchronization primitives. The contract is:
+        # - only the producer (the `send` method) can increment the write counter
         # - only the consumer (the `_audio_stream` generator) can increment the read counter
         # - the read counter can never surpass the write counter
         # - both the consumer and producer can read both counters to compute the fill level
-        # Since this this fill is not protected by a lock, it represents:
+        # Since this fill is not protected by a lock, it represents:
         # - a maximum fill level when it's read by the producer
         # - a minimum fill level when it's read by the consumer
         self.write_counter = 0
         self.read_counter = 0
 
+        # Diagnostics variables
+        self._underruns = 0
+        self._overruns = 0
+        self._diag_enabled = bool(
+            os.environ.get("GAMBATERM_AUDIO_CSV")
+            or os.environ.get("GAMBATERM_AUDIO_LOG")
+        )
+        if self._diag_enabled:
+            self._diag_frames: list[dict] = []
+            self._diag_frame_num = 0
+            self._diag_fill_min = 1.0
+            self._diag_ratio_min = self.nominal_sampling_ratio
+            self._diag_ratio_max = self.nominal_sampling_ratio
+            atexit.register(self._dump_audio_stats)
+
         # Controller configuration
         self.correction_min = 1 - self.correction_clamp
         self.correction_max = 1 + self.correction_clamp
+
+        # Batch variable-length emulator output to avoid starving the
+        # ring buffer as runFor() sometimes returns partial frames.
+        self._acc_buf: npt.NDArray[np.float32] = np.empty((0, 2), dtype=np.float32)
 
         # Controller state
         self.last_buffer_levels = deque[float](maxlen=self.ma_length)
@@ -86,10 +107,35 @@ class AudioOut:
         device.start(stream)
         return device
 
+    def _dump_audio_stats(self) -> None:
+        if (audio_log := os.environ.get("GAMBATERM_AUDIO_LOG")):
+            with open(audio_log, "w") as fout:
+                fout.write(f"underruns={self._underruns}\n")
+                fout.write(f"overruns={self._overruns}\n")
+                fout.write(f"fill_min={self._diag_fill_min:.4f}\n")
+                fout.write(f"ratio_min={self._diag_ratio_min:.8f}\n")
+                fout.write(f"ratio_max={self._diag_ratio_max:.8f}\n")
+                _rng = self._diag_ratio_max - self._diag_ratio_min
+                fout.write(f"ratio_range={_rng:.8f}\n")
+        if (diag_csv := os.environ.get("GAMBATERM_AUDIO_CSV")):
+            with open(diag_csv, "w") as fout:
+                fout.write("frame,input,acc,proc,output,fill\n")
+                for _df in self._diag_frames:
+                    fout.write(
+                        f"{_df['frame']},{_df['input']},{_df['acc']},"
+                        f"{_df['proc']},{_df['output']},{_df['fill']:.4f}\n"
+                    )
+
+    @property
+    def fill_fraction(self) -> float:
+        # Ring buffer fill ratio (0-1.0)
+        if self.ring_size == 0:
+            return 0.0
+        return (self.write_counter - self.read_counter) / self.ring_size
+
     def adapt_sample_rate(self) -> None:
         # First perform a short moving average of the last 5 measurements
-        ring_fill = self.write_counter - self.read_counter
-        self.last_buffer_levels.append(ring_fill / self.ring_size)
+        self.last_buffer_levels.append(self.fill_fraction)
         buffer_level = sum(self.last_buffer_levels) / len(self.last_buffer_levels)
 
         # Then perform a longer exponential moving average
@@ -113,13 +159,77 @@ class AudioOut:
 
         # Return the adjusted sample rate
         self.sampling_ratio = self.nominal_sampling_ratio * correction
+        self._diag_track_ratio()
+
+    def _diag_record_skip(self, input_len: int, acc_len: int) -> None:
+        if not self._diag_enabled:
+            return
+        fill = self.fill_fraction
+        self._diag_fill_min = min(self._diag_fill_min, fill)
+        self._diag_frames.append({
+            "frame": self._diag_frame_num,
+            "input": input_len,
+            "acc": acc_len,
+            "proc": 0,
+            "output": 0,
+            "fill": fill,
+        })
+        self._diag_frame_num += 1
+
+    def _diag_record_process(
+        self, input_len: int, acc_len: int, output_len: int,
+    ) -> None:
+        if not self._diag_enabled:
+            return
+        fill = self.fill_fraction
+        self._diag_fill_min = min(self._diag_fill_min, fill)
+        self._diag_frames.append({
+            "frame": self._diag_frame_num,
+            "input": input_len,
+            "acc": acc_len,
+            "proc": 1,
+            "output": output_len,
+            "fill": fill,
+        })
+        self._diag_frame_num += 1
+
+    def _diag_track_fill(self) -> None:
+        if not self._diag_enabled:
+            return
+        self._diag_fill_min = min(self._diag_fill_min, self.fill_fraction)
+
+    def _diag_track_ratio(self) -> None:
+        if not self._diag_enabled:
+            return
+        self._diag_ratio_min = min(self._diag_ratio_min, self.sampling_ratio)
+        self._diag_ratio_max = max(self._diag_ratio_max, self.sampling_ratio)
 
     def send(self, console: Console, audio: npt.NDArray[np.int16]) -> None:
-        # Resample input audio to output rate with speed adjustment
-        resampled = self.resampler.process(
-            audio * self.audio_volume - console.AUDIO_OFFSET * self.audio_volume,
-            self.sampling_ratio,
-        ).astype(np.int16)
+        # Scale and remove DC offset
+        scaled = (audio.astype(np.float32) * self.audio_volume
+                  - console.AUDIO_OFFSET * self.audio_volume)
+
+        # Accumulate input to batch variable-length emulator frames into consistent chunks for the
+        # resampler.  The emulator's runFor() may produce anywhere from a few hundred to tens of
+        # thousands of samples per call; tiny batches could otherwise starve the ring buffer when
+        # under load.
+        self._acc_buf = np.concatenate([self._acc_buf, scaled])
+        input_len = len(scaled)
+        acc_len = len(self._acc_buf)
+
+        # Process when we have enough to produce ~5ms of output at 48 kHz,
+        # or when we have accumulated more than 3 video frames (safety valve).
+        min_output = 240
+        min_input = max(1, int(min_output / self.sampling_ratio))
+        max_input = console.TICKS_IN_FRAME * 3
+        if acc_len < min_input and acc_len < max_input:
+            self._diag_record_skip(input_len, acc_len)
+            return
+
+        chunk = self._acc_buf
+        self._acc_buf = np.empty((0, 2), dtype=np.float32)
+        resampled = self.resampler.process(chunk, self.sampling_ratio)
+        resampled = np.clip(resampled, -32768, 32767).astype(np.int16)
 
         # Get the ring buffer
         ring_buffer = self.ring_buffer
@@ -135,7 +245,7 @@ class AudioOut:
 
         # Drop excess frames if we're overrun
         if frames > space:
-            # TODO: Implement logging
+            self._overruns += 1
             resampled = resampled[:space]
             frames = space
 
@@ -157,6 +267,7 @@ class AudioOut:
 
         # Update the write counter
         self.write_counter += frames
+        self._diag_record_process(input_len, acc_len, frames)
 
     def _audio_stream(self) -> Generator[bytes, int, None]:
         # Get the ring buffer
@@ -201,11 +312,11 @@ class AudioOut:
 
             # Update the read counter
             self.read_counter += read_size
+            self._diag_track_fill()
 
             # Log if we're underrunning
             if read_size < required_frames:
-                # TODO: Implement logging
-                pass
+                self._underruns += 1
 
             # Send audio to output and get next required frames
             required_frames = yield result.tobytes()

--- a/gambaterm/audio.py
+++ b/gambaterm/audio.py
@@ -131,7 +131,7 @@ class AudioOut:
         # Ring buffer fill ratio (0-1.0)
         if self.ring_size == 0:
             return 0.0
-        return (self.write_counter - self.read_counter) / self.ring_size
+        return max(0.0, (self.write_counter - self.read_counter) / self.ring_size)
 
     def adapt_sample_rate(self) -> None:
         # First perform a short moving average of the last 5 measurements

--- a/gambaterm/audio.py
+++ b/gambaterm/audio.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import atexit
+import logging
 import os
 from typing import Generator, Iterator, TYPE_CHECKING
 from contextlib import contextmanager
@@ -15,6 +16,8 @@ from .console import Console
 if TYPE_CHECKING:
     import miniaudio
     import samplerate
+
+logger = logging.getLogger(__name__)
 
 
 class AudioOut:
@@ -66,24 +69,22 @@ class AudioOut:
         # Diagnostics variables
         self._underruns = 0
         self._overruns = 0
-        self._diag_enabled = bool(
-            os.environ.get("GAMBATERM_AUDIO_CSV")
-            or os.environ.get("GAMBATERM_AUDIO_LOG")
-        )
-        if self._diag_enabled:
+        self._frame_num = 0
+        self._csv_enabled = bool(os.environ.get("GAMBATERM_AUDIO_CSV"))
+        self._diag_fill_min = 1.0
+        self._diag_ratio_min = self.nominal_sampling_ratio
+        self._diag_ratio_max = self.nominal_sampling_ratio
+        if self._csv_enabled:
             self._diag_frames: list[dict] = []
-            self._diag_frame_num = 0
-            self._diag_fill_min = 1.0
-            self._diag_ratio_min = self.nominal_sampling_ratio
-            self._diag_ratio_max = self.nominal_sampling_ratio
-            atexit.register(self._dump_audio_stats)
+            atexit.register(self._dump_csv)
+        atexit.register(self._log_summary)
 
         # Controller configuration
         self.correction_min = 1 - self.correction_clamp
         self.correction_max = 1 + self.correction_clamp
 
-        # Batch variable-length emulator output to avoid starving the
-        # ring buffer as runFor() sometimes returns partial frames.
+        # Batch the variable-length emulator audio output, avoids starving the ring buffer, runFor()
+        # sometimes returns partial frames!
         self._acc_buf: npt.NDArray[np.float32] = np.empty((0, 2), dtype=np.float32)
 
         # Controller state
@@ -107,17 +108,8 @@ class AudioOut:
         device.start(stream)
         return device
 
-    def _dump_audio_stats(self) -> None:
-        if (audio_log := os.environ.get("GAMBATERM_AUDIO_LOG")):
-            with open(audio_log, "w") as fout:
-                fout.write(f"underruns={self._underruns}\n")
-                fout.write(f"overruns={self._overruns}\n")
-                fout.write(f"fill_min={self._diag_fill_min:.4f}\n")
-                fout.write(f"ratio_min={self._diag_ratio_min:.8f}\n")
-                fout.write(f"ratio_max={self._diag_ratio_max:.8f}\n")
-                _rng = self._diag_ratio_max - self._diag_ratio_min
-                fout.write(f"ratio_range={_rng:.8f}\n")
-        if (diag_csv := os.environ.get("GAMBATERM_AUDIO_CSV")):
+    def _dump_csv(self) -> None:
+        if diag_csv := os.environ.get("GAMBATERM_AUDIO_CSV"):
             with open(diag_csv, "w") as fout:
                 fout.write("frame,input,acc,proc,output,fill\n")
                 for _df in self._diag_frames:
@@ -125,6 +117,19 @@ class AudioOut:
                         f"{_df['frame']},{_df['input']},{_df['acc']},"
                         f"{_df['proc']},{_df['output']},{_df['fill']:.4f}\n"
                     )
+
+    def _log_summary(self) -> None:
+        logger.debug(
+            "Audio stats: underruns=%d overruns=%d "
+            "fill_min=%.4f ratio_min=%.8f ratio_max=%.8f "
+            "ratio_range=%.8f",
+            self._underruns,
+            self._overruns,
+            self._diag_fill_min,
+            self._diag_ratio_min,
+            self._diag_ratio_max,
+            self._diag_ratio_max - self._diag_ratio_min,
+        )
 
     @property
     def fill_fraction(self) -> float:
@@ -162,52 +167,68 @@ class AudioOut:
         self._diag_track_ratio()
 
     def _diag_record_skip(self, input_len: int, acc_len: int) -> None:
-        if not self._diag_enabled:
-            return
         fill = self.fill_fraction
         self._diag_fill_min = min(self._diag_fill_min, fill)
-        self._diag_frames.append({
-            "frame": self._diag_frame_num,
-            "input": input_len,
-            "acc": acc_len,
-            "proc": 0,
-            "output": 0,
-            "fill": fill,
-        })
-        self._diag_frame_num += 1
+        frame = self._frame_num
+        self._frame_num += 1
+        logger.debug(
+            "skip frame=%d input=%d acc=%d fill=%.4f", frame, input_len, acc_len, fill
+        )
+        if self._csv_enabled:
+            self._diag_frames.append(
+                {
+                    "frame": frame,
+                    "input": input_len,
+                    "acc": acc_len,
+                    "proc": 0,
+                    "output": 0,
+                    "fill": fill,
+                }
+            )
 
     def _diag_record_process(
-        self, input_len: int, acc_len: int, output_len: int,
+        self,
+        input_len: int,
+        acc_len: int,
+        output_len: int,
     ) -> None:
-        if not self._diag_enabled:
-            return
         fill = self.fill_fraction
         self._diag_fill_min = min(self._diag_fill_min, fill)
-        self._diag_frames.append({
-            "frame": self._diag_frame_num,
-            "input": input_len,
-            "acc": acc_len,
-            "proc": 1,
-            "output": output_len,
-            "fill": fill,
-        })
-        self._diag_frame_num += 1
+        frame = self._frame_num
+        self._frame_num += 1
+        logger.debug(
+            "process frame=%d input=%d acc=%d output=%d fill=%.4f",
+            frame,
+            input_len,
+            acc_len,
+            output_len,
+            fill,
+        )
+        if self._csv_enabled:
+            self._diag_frames.append(
+                {
+                    "frame": frame,
+                    "input": input_len,
+                    "acc": acc_len,
+                    "proc": 1,
+                    "output": output_len,
+                    "fill": fill,
+                }
+            )
 
     def _diag_track_fill(self) -> None:
-        if not self._diag_enabled:
-            return
         self._diag_fill_min = min(self._diag_fill_min, self.fill_fraction)
 
     def _diag_track_ratio(self) -> None:
-        if not self._diag_enabled:
-            return
         self._diag_ratio_min = min(self._diag_ratio_min, self.sampling_ratio)
         self._diag_ratio_max = max(self._diag_ratio_max, self.sampling_ratio)
 
     def send(self, console: Console, audio: npt.NDArray[np.int16]) -> None:
         # Scale and remove DC offset
-        scaled = (audio.astype(np.float32) * self.audio_volume
-                  - console.AUDIO_OFFSET * self.audio_volume)
+        scaled = (
+            audio.astype(np.float32) * self.audio_volume
+            - console.AUDIO_OFFSET * self.audio_volume
+        )
 
         # Accumulate input to batch variable-length emulator frames into consistent chunks for the
         # resampler.  The emulator's runFor() may produce anywhere from a few hundred to tens of
@@ -246,6 +267,12 @@ class AudioOut:
         # Drop excess frames if we're overrun
         if frames > space:
             self._overruns += 1
+            logger.warning(
+                "Audio overrun: dropping %d of %d frames (fill=%.2f)",
+                frames - space,
+                frames,
+                self.fill_fraction,
+            )
             resampled = resampled[:space]
             frames = space
 
@@ -317,6 +344,12 @@ class AudioOut:
             # Log if we're underrunning
             if read_size < required_frames:
                 self._underruns += 1
+                logger.warning(
+                    "Audio underrun: requested %d, got %d (fill=%.2f)",
+                    required_frames,
+                    read_size,
+                    self.fill_fraction,
+                )
 
             # Send audio to output and get next required frames
             required_frames = yield result.tobytes()

--- a/gambaterm/audio.py
+++ b/gambaterm/audio.py
@@ -171,9 +171,6 @@ class AudioOut:
         self._diag_fill_min = min(self._diag_fill_min, fill)
         frame = self._frame_num
         self._frame_num += 1
-        logger.debug(
-            "skip frame=%d input=%d acc=%d fill=%.4f", frame, input_len, acc_len, fill
-        )
         if self._csv_enabled:
             self._diag_frames.append(
                 {
@@ -196,14 +193,6 @@ class AudioOut:
         self._diag_fill_min = min(self._diag_fill_min, fill)
         frame = self._frame_num
         self._frame_num += 1
-        logger.debug(
-            "process frame=%d input=%d acc=%d output=%d fill=%.4f",
-            frame,
-            input_len,
-            acc_len,
-            output_len,
-            fill,
-        )
         if self._csv_enabled:
             self._diag_frames.append(
                 {

--- a/gambaterm/audio.py
+++ b/gambaterm/audio.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import atexit
-import logging
-import os
-from typing import Any, Generator, Iterator, TYPE_CHECKING
+from typing import Generator, Iterator, TYPE_CHECKING
 from contextlib import contextmanager
 from collections import deque
 
 import numpy as np
 import numpy.typing as npt
+import structlog
 
 from .console import Console
 
@@ -17,7 +16,7 @@ if TYPE_CHECKING:
     import miniaudio
     import samplerate
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 class AudioOut:
@@ -55,12 +54,12 @@ class AudioOut:
         self.ring_buffer = np.zeros((self.ring_size, 2), dtype=np.int16)
 
         # We implement a SPSC (Single Producer Single Consumer) ring buffer,
-        # so we do not need synchronization primitives. The contract is:
-        # - only the producer (the `send` method) can increment the write counter
+        # so we do not need synchonization primitives. The contract is:
+        # - only the producer (the `send` method) can incremement the write counter
         # - only the consumer (the `_audio_stream` generator) can increment the read counter
         # - the read counter can never surpass the write counter
         # - both the consumer and producer can read both counters to compute the fill level
-        # Since this fill is not protected by a lock, it represents:
+        # Since this this fill is not protected by a lock, it represents:
         # - a maximum fill level when it's read by the producer
         # - a minimum fill level when it's read by the consumer
         self.write_counter = 0
@@ -69,23 +68,14 @@ class AudioOut:
         # Diagnostics variables
         self._underruns = 0
         self._overruns = 0
-        self._frame_num = 0
-        self._csv_enabled = bool(os.environ.get("GAMBATERM_AUDIO_CSV"))
         self._diag_fill_min = 1.0
         self._diag_ratio_min = self.nominal_sampling_ratio
         self._diag_ratio_max = self.nominal_sampling_ratio
-        if self._csv_enabled:
-            self._diag_frames: list[dict[str, Any]] = []
-            atexit.register(self._dump_csv)
         atexit.register(self._log_summary)
 
         # Controller configuration
         self.correction_min = 1 - self.correction_clamp
         self.correction_max = 1 + self.correction_clamp
-
-        # Batch the variable-length emulator audio output, avoids starving the ring buffer, runFor()
-        # sometimes returns partial frames!
-        self._acc_buf: npt.NDArray[np.float32] = np.empty((0, 2), dtype=np.float32)
 
         # Controller state
         self.last_buffer_levels = deque[float](maxlen=self.ma_length)
@@ -108,27 +98,15 @@ class AudioOut:
         device.start(stream)
         return device
 
-    def _dump_csv(self) -> None:
-        if diag_csv := os.environ.get("GAMBATERM_AUDIO_CSV"):
-            with open(diag_csv, "w") as fout:
-                fout.write("frame,input,acc,proc,output,fill\n")
-                for _df in self._diag_frames:
-                    fout.write(
-                        f"{_df['frame']},{_df['input']},{_df['acc']},"
-                        f"{_df['proc']},{_df['output']},{_df['fill']:.4f}\n"
-                    )
-
     def _log_summary(self) -> None:
         logger.debug(
-            "Audio stats: underruns=%d overruns=%d "
-            "fill_min=%.4f ratio_min=%.8f ratio_max=%.8f "
-            "ratio_range=%.8f",
-            self._underruns,
-            self._overruns,
-            self._diag_fill_min,
-            self._diag_ratio_min,
-            self._diag_ratio_max,
-            self._diag_ratio_max - self._diag_ratio_min,
+            "audio_summary",
+            underruns=self._underruns,
+            overruns=self._overruns,
+            fill_min=self._diag_fill_min,
+            ratio_min=self._diag_ratio_min,
+            ratio_max=self._diag_ratio_max,
+            ratio_range=self._diag_ratio_max - self._diag_ratio_min,
         )
 
     @property
@@ -164,82 +142,16 @@ class AudioOut:
 
         # Return the adjusted sample rate
         self.sampling_ratio = self.nominal_sampling_ratio * correction
-        self._diag_track_ratio()
-
-    def _diag_record_skip(self, input_len: int, acc_len: int) -> None:
-        fill = self.fill_fraction
-        self._diag_fill_min = min(self._diag_fill_min, fill)
-        frame = self._frame_num
-        self._frame_num += 1
-        if self._csv_enabled:
-            self._diag_frames.append(
-                {
-                    "frame": frame,
-                    "input": input_len,
-                    "acc": acc_len,
-                    "proc": 0,
-                    "output": 0,
-                    "fill": fill,
-                }
-            )
-
-    def _diag_record_process(
-        self,
-        input_len: int,
-        acc_len: int,
-        output_len: int,
-    ) -> None:
-        fill = self.fill_fraction
-        self._diag_fill_min = min(self._diag_fill_min, fill)
-        frame = self._frame_num
-        self._frame_num += 1
-        if self._csv_enabled:
-            self._diag_frames.append(
-                {
-                    "frame": frame,
-                    "input": input_len,
-                    "acc": acc_len,
-                    "proc": 1,
-                    "output": output_len,
-                    "fill": fill,
-                }
-            )
-
-    def _diag_track_fill(self) -> None:
-        self._diag_fill_min = min(self._diag_fill_min, self.fill_fraction)
-
-    def _diag_track_ratio(self) -> None:
         self._diag_ratio_min = min(self._diag_ratio_min, self.sampling_ratio)
         self._diag_ratio_max = max(self._diag_ratio_max, self.sampling_ratio)
 
     def send(self, console: Console, audio: npt.NDArray[np.int16]) -> None:
-        # Scale and remove DC offset
-        scaled = (
+        # Resample input audio to output rate with speed adjustment
+        resampled = self.resampler.process(
             audio.astype(np.float32) * self.audio_volume
-            - console.AUDIO_OFFSET * self.audio_volume
-        )
-
-        # Accumulate input to batch variable-length emulator frames into consistent chunks for the
-        # resampler.  The emulator's runFor() may produce anywhere from a few hundred to tens of
-        # thousands of samples per call; tiny batches could otherwise starve the ring buffer when
-        # under load.
-        self._acc_buf = np.concatenate([self._acc_buf, scaled])
-        input_len = len(scaled)
-        acc_len = len(self._acc_buf)
-
-        # Process when we have enough to produce ~5ms of output at 48 kHz,
-        # or when we have accumulated more than 3 video frames (safety valve).
-        min_output = 240
-        min_input = max(1, int(min_output / self.sampling_ratio))
-        max_input = console.TICKS_IN_FRAME * 3
-        if acc_len < min_input and acc_len < max_input:
-            self._diag_record_skip(input_len, acc_len)
-            return
-
-        chunk = self._acc_buf
-        self._acc_buf = np.empty((0, 2), dtype=np.float32)
-        resampled = self.resampler.process(chunk, self.sampling_ratio)
-        resampled = np.clip(resampled, -32768, 32767).astype(np.int16)
+            - console.AUDIO_OFFSET * self.audio_volume,
+            self.sampling_ratio,
+        ).astype(np.int16)
 
         # Get the ring buffer
         ring_buffer = self.ring_buffer
@@ -257,10 +169,10 @@ class AudioOut:
         if frames > space:
             self._overruns += 1
             logger.warning(
-                "Audio overrun: dropping %d of %d frames (fill=%.2f)",
-                frames - space,
-                frames,
-                self.fill_fraction,
+                "audio_overrun",
+                dropped=frames - space,
+                frames=frames,
+                fill=self.fill_fraction,
             )
             resampled = resampled[:space]
             frames = space
@@ -283,7 +195,13 @@ class AudioOut:
 
         # Update the write counter
         self.write_counter += frames
-        self._diag_record_process(input_len, acc_len, frames)
+        self._diag_fill_min = min(self._diag_fill_min, self.fill_fraction)
+        logger.debug(
+            "audio_frame",
+            input=len(audio),
+            output=frames,
+            fill=self.fill_fraction,
+        )
 
     def _audio_stream(self) -> Generator[bytes, int, None]:
         # Get the ring buffer
@@ -328,16 +246,16 @@ class AudioOut:
 
             # Update the read counter
             self.read_counter += read_size
-            self._diag_track_fill()
+            self._diag_fill_min = min(self._diag_fill_min, self.fill_fraction)
 
             # Log if we're underrunning
             if read_size < required_frames:
                 self._underruns += 1
                 logger.warning(
-                    "Audio underrun: requested %d, got %d (fill=%.2f)",
-                    required_frames,
-                    read_size,
-                    self.fill_fraction,
+                    "audio_underrun",
+                    required=required_frames,
+                    got=read_size,
+                    fill=self.fill_fraction,
                 )
 
             # Send audio to output and get next required frames

--- a/gambaterm/audio.py
+++ b/gambaterm/audio.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import atexit
 import logging
 import os
-from typing import Generator, Iterator, TYPE_CHECKING
+from typing import Any, Generator, Iterator, TYPE_CHECKING
 from contextlib import contextmanager
 from collections import deque
 
@@ -75,7 +75,7 @@ class AudioOut:
         self._diag_ratio_min = self.nominal_sampling_ratio
         self._diag_ratio_max = self.nominal_sampling_ratio
         if self._csv_enabled:
-            self._diag_frames: list[dict] = []
+            self._diag_frames: list[dict[str, Any]] = []
             atexit.register(self._dump_csv)
         atexit.register(self._log_summary)
 

--- a/gambaterm/main.py
+++ b/gambaterm/main.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import time
+import logging
 import argparse
 from pathlib import Path
-from typing import ContextManager, TYPE_CHECKING
+from typing import Any, ContextManager, Optional, TYPE_CHECKING
 import dataclasses
 from dataclasses import dataclass, field
 
@@ -22,6 +23,45 @@ from .file_input import console_input_from_file_context, write_input_context
 # `typing.Self` is not available in python 3.10
 if TYPE_CHECKING:
     from typing import Self
+
+_DEFAULT_LOGFMT = " ".join(("%(levelname)s", "%(filename)s:%(lineno)d", "%(message)s"))
+
+
+def make_logger(
+    name: str,
+    loglevel: str = "info",
+    logfile: Optional[str] = None,
+    logfmt: str = _DEFAULT_LOGFMT,
+    filemode: str = "a",
+) -> logging.Logger:
+    """Create and return a configured logger (following telnetlib3 pattern)."""
+    lvl = getattr(logging, loglevel.upper(), None)
+    if lvl is None:
+        lvl = logging.getLevelName(loglevel.upper())
+    _cfg: dict[str, Any] = {"format": logfmt}
+    if logfile:
+        _cfg["filename"] = logfile
+        _cfg["filemode"] = filemode
+    logging.basicConfig(**_cfg)
+    logging.getLogger().setLevel(lvl)
+    logging.getLogger(name).setLevel(lvl)
+    return logging.getLogger(name)
+
+
+def add_logging_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--logfile", default=None, help="File path for log output (default: stderr)"
+    )
+    parser.add_argument(
+        "--loglevel",
+        default="warn",
+        help="Logging level: debug, info, warn, error (default: warn)",
+    )
+    parser.add_argument(
+        "--logfmt",
+        default=_DEFAULT_LOGFMT,
+        help="Log format string (default: LEVEL file:lineno message)",
+    )
 
 
 @dataclass
@@ -151,11 +191,18 @@ def main(
     add_base_arguments(parser)
     add_input_file_arguments(parser)
     add_tuning_arguments(parser)
+    add_logging_arguments(parser)
     add_local_only_arguments(parser)
     console_cls.add_console_arguments(parser)
 
     # Parse arguments
     namespace = parser.parse_args(parser_args)
+    make_logger(
+        __name__,
+        loglevel=getattr(namespace, "loglevel", "warn"),
+        logfile=getattr(namespace, "logfile", None),
+        logfmt=getattr(namespace, "logfmt", _DEFAULT_LOGFMT),
+    )
     disable_audio = getattr(namespace, "disable_audio", False)
     args = LocalAppConfig.from_namespace(namespace)
 

--- a/gambaterm/main.py
+++ b/gambaterm/main.py
@@ -9,6 +9,7 @@ from typing import Any, ContextManager, Optional, TYPE_CHECKING
 import dataclasses
 from dataclasses import dataclass, field
 
+import structlog
 from blessed import Terminal
 
 from .run import run
@@ -34,7 +35,7 @@ def make_logger(
     logfmt: str = _DEFAULT_LOGFMT,
     filemode: str = "a",
 ) -> logging.Logger:
-    """Create and return a configured logger (following telnetlib3 pattern)."""
+    """Create and return a configured logger."""
     lvl = getattr(logging, loglevel.upper(), None)
     if lvl is None:
         lvl = logging.getLevelName(loglevel.upper())
@@ -45,6 +46,27 @@ def make_logger(
     logging.basicConfig(**_cfg)
     logging.getLogger().setLevel(lvl)
     logging.getLogger(name).setLevel(lvl)
+
+    # Route structlog through standard logging so --logfile can be used
+    # to capture debug output when running locally without muddying up
+    # the screen's display
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
     return logging.getLogger(name)
 
 
@@ -54,8 +76,8 @@ def add_logging_arguments(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--loglevel",
-        default="warn",
-        help="Logging level: debug, info, warn, error (default: warn)",
+        default="info",
+        help="Logging level: debug, info, warn, error, critical (default: critical for local, info for ssh/telnet)",
     )
     parser.add_argument(
         "--logfmt",
@@ -192,6 +214,7 @@ def main(
     add_input_file_arguments(parser)
     add_tuning_arguments(parser)
     add_logging_arguments(parser)
+    parser.set_defaults(loglevel="critical")
     add_local_only_arguments(parser)
     console_cls.add_console_arguments(parser)
 
@@ -199,7 +222,7 @@ def main(
     namespace = parser.parse_args(parser_args)
     make_logger(
         __name__,
-        loglevel=getattr(namespace, "loglevel", "warn"),
+        loglevel=getattr(namespace, "loglevel", "critical"),
         logfile=getattr(namespace, "logfile", None),
         logfmt=getattr(namespace, "logfmt", _DEFAULT_LOGFMT),
     )

--- a/gambaterm/run.py
+++ b/gambaterm/run.py
@@ -36,7 +36,7 @@ def get_ref(width: int, height: int, console: Console) -> tuple[int, int]:
     return refx, refy
 
 
-def write_frame(term: Terminal, frame_data: bytes) -> None:
+def write_frame(term: Terminal, frame_data: bytes | bytearray) -> None:
     # Fix code page issue on windows:
     # `sys.stdout.buffer.raw` is a `WindowsConsoleIO` that always support UTF-8
     # regardless of the configured codepage

--- a/gambaterm/ssh.py
+++ b/gambaterm/ssh.py
@@ -576,7 +576,7 @@ def main(
     namespace = parser.parse_args(parser_args)
     make_logger(
         __name__,
-        loglevel=getattr(namespace, "loglevel", "warn"),
+        loglevel=getattr(namespace, "loglevel", "info"),
         logfile=getattr(namespace, "logfile", None),
         logfmt=getattr(namespace, "logfmt", _DEFAULT_LOGFMT),
     )

--- a/gambaterm/ssh.py
+++ b/gambaterm/ssh.py
@@ -38,6 +38,9 @@ from .main import (
     add_base_arguments,
     add_input_file_arguments,
     add_tuning_arguments,
+    add_logging_arguments,
+    make_logger,
+    _DEFAULT_LOGFMT,
     AppConfig,
 )
 from .console import Console, GameboyColor
@@ -533,6 +536,7 @@ def main(
     add_base_arguments(parser)
     add_input_file_arguments(parser)
     add_tuning_arguments(parser)
+    add_logging_arguments(parser)
     console_cls.add_console_arguments(parser)
     parser.add_argument(
         "--bind",
@@ -570,6 +574,12 @@ def main(
 
     # Parse arguments
     namespace = parser.parse_args(parser_args)
+    make_logger(
+        __name__,
+        loglevel=getattr(namespace, "loglevel", "warn"),
+        logfile=getattr(namespace, "logfile", None),
+        logfmt=getattr(namespace, "logfmt", _DEFAULT_LOGFMT),
+    )
     bind: str = namespace.__dict__.pop("bind")
     port: int = namespace.__dict__.pop("port")
     password: str = namespace.__dict__.pop("password")

--- a/gambaterm/telnet.py
+++ b/gambaterm/telnet.py
@@ -493,7 +493,7 @@ def main(
     namespace = parser.parse_args(parser_args)
     make_logger(
         __name__,
-        loglevel=getattr(namespace, "loglevel", "warn"),
+        loglevel=getattr(namespace, "loglevel", "info"),
         logfile=getattr(namespace, "logfile", None),
         logfmt=getattr(namespace, "logfmt", _DEFAULT_LOGFMT),
     )

--- a/gambaterm/telnet.py
+++ b/gambaterm/telnet.py
@@ -32,6 +32,9 @@ from .main import (
     add_base_arguments,
     add_input_file_arguments,
     add_tuning_arguments,
+    add_logging_arguments,
+    make_logger,
+    _DEFAULT_LOGFMT,
     AppConfig,
 )
 from .console import Console, GameboyColor
@@ -444,6 +447,7 @@ def main(
     add_base_arguments(parser)
     add_input_file_arguments(parser)
     add_tuning_arguments(parser)
+    add_logging_arguments(parser)
     console_cls.add_console_arguments(parser)
     parser.add_argument(
         "--bind",
@@ -464,8 +468,7 @@ def main(
         "--robot-check",
         action="store_true",
         default=False,
-        help="reject bots by checking if client responds to "
-        "cursor position requests",
+        help="reject bots by checking if client responds to cursor position requests",
     )
     parser.add_argument(
         "--port",
@@ -488,6 +491,12 @@ def main(
     )
 
     namespace = parser.parse_args(parser_args)
+    make_logger(
+        __name__,
+        loglevel=getattr(namespace, "loglevel", "warn"),
+        logfile=getattr(namespace, "logfile", None),
+        logfmt=getattr(namespace, "logfmt", _DEFAULT_LOGFMT),
+    )
     bind: str = namespace.__dict__.pop("bind")
     port: int = namespace.__dict__.pop("port")
     robot_check: bool = namespace.__dict__.pop("robot_check")


### PR DESCRIPTION
Replace the TODO stubs for underrun/overrun logging and add per-frame audio telemetry via `structlog`.

Add `--logfile` / `--loglevel` / `--logfmt` on all entry points (local, SSH, telnet), this is copied from telnetlib3. This is tricky because we really shouldn't log anything when run locally unless ``--logfile`` is also used .. so I have changed loglevel to default to critical for local execution, and info for ssh/telnet.